### PR TITLE
feat: change API facade

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -18,8 +18,7 @@
     "__fixtures__",
     "coverage",
     "dist",
-    "scripts",
-    "website",
+    "e2e",
     "*.js"
   ],
   "parser": "@typescript-eslint/parser",

--- a/e2e/jest.config.js
+++ b/e2e/jest.config.js
@@ -1,0 +1,19 @@
+const base = require('../jest.config');
+
+module.exports = {
+  ...base,
+
+  rootDir: '..',
+  testEnvironment: 'jest-environment-emit/node',
+  testEnvironmentOptions: {
+    eventListeners: [
+      './e2e/listeners.cjs',
+      './e2e/listeners.mjs',
+      {
+        test_environment_teardown() {
+          console.log('[inline] test_environment_teardown');
+        },
+      },
+    ],
+  },
+};

--- a/e2e/jest.config.js
+++ b/e2e/jest.config.js
@@ -7,13 +7,8 @@ module.exports = {
   testEnvironment: 'jest-environment-emit/node',
   testEnvironmentOptions: {
     eventListeners: [
-      './e2e/listeners.cjs',
-      './e2e/listeners.mjs',
-      {
-        test_environment_teardown() {
-          console.log('[inline] test_environment_teardown');
-        },
-      },
+      ['./e2e/listeners.cjs', { prefix: 'cjs' }],
+      ['./e2e/listeners.mjs', { prefix: 'mjs' }],
     ],
   },
 };

--- a/e2e/listeners.cjs
+++ b/e2e/listeners.cjs
@@ -1,0 +1,5 @@
+module.exports = ({ testEvents }) => {
+  testEvents.on('test_environment_teardown', () => {
+    console.log('[cjs] test_environment_teardown');
+  });
+};

--- a/e2e/listeners.cjs
+++ b/e2e/listeners.cjs
@@ -1,5 +1,6 @@
-module.exports = ({ testEvents }) => {
+/** @type {import('jest-environment-emit').EnvironmentListenerFn} */
+module.exports = ({ testEvents }, { prefix }) => {
   testEvents.on('test_environment_teardown', () => {
-    console.log('[cjs] test_environment_teardown');
+    console.log(`[${prefix}] test_environment_teardown`);
   });
 };

--- a/e2e/listeners.mjs
+++ b/e2e/listeners.mjs
@@ -1,6 +1,6 @@
-/** @type {import('jest-environment-emit').Subscription} */
-export default ({ testEvents }) => {
+/** @type {import('jest-environment-emit').EnvironmentListenerFn} */
+export default ({ testEvents }, { prefix }) => {
   testEvents.on('test_environment_teardown', () => {
-    console.log('[cjs] test_environment_teardown');
+    console.log(`[${prefix}] test_environment_teardown`);
   });
 };

--- a/e2e/listeners.mjs
+++ b/e2e/listeners.mjs
@@ -1,0 +1,6 @@
+/** @type {import('jest-environment-emit').Subscription} */
+export default ({ testEvents }) => {
+  testEvents.on('test_environment_teardown', () => {
+    console.log('[cjs] test_environment_teardown');
+  });
+};

--- a/hooks.js
+++ b/hooks.js
@@ -1,2 +1,0 @@
-/* Jest 27 fallback */
-module.exports = require('./dist/environment-hooks');

--- a/jest.config.js
+++ b/jest.config.js
@@ -1,9 +1,10 @@
 const CI = require('is-ci');
 
-/** @type {import('@jest/types').Config} */
+/** @type {import('jest').Config} */
 module.exports = {
   collectCoverage: CI,
   coverageDirectory: '../../artifacts/unit/coverage',
+  modulePathIgnorePatterns: [/dist/, /node_modules/, /e2e/].map((s) => s.source),
   preset: 'ts-jest',
   testMatch: [
     '<rootDir>/src/**/*.test.{js,ts}',

--- a/jsdom.js
+++ b/jsdom.js
@@ -1,2 +1,2 @@
 /* Jest 27 fallback */
-module.exports = require('./dist/environment-jsdom');
+module.exports = require('./dist/jsdom');

--- a/node.js
+++ b/node.js
@@ -1,2 +1,2 @@
 /* Jest 27 fallback */
-module.exports = require('./dist/environment-node');
+module.exports = require('./dist/node');

--- a/package.json
+++ b/package.json
@@ -19,11 +19,6 @@
       "require": "./dist/index.js",
       "types": "./dist/index.d.ts"
     },
-    "./hooks": {
-      "import": "./dist/hooks.js",
-      "require": "./dist/hooks.js",
-      "types": "./dist/hooks.d.ts"
-    },
     "./jsdom": {
       "import": "./dist/jsdom.js",
       "require": "./dist/jsdom.js",

--- a/src/__tests__/index.test.ts
+++ b/src/__tests__/index.test.ts
@@ -3,12 +3,6 @@ import JestEnvironmentEmit from '../index';
 describe('EmitterMixin', () => {
   it('should be able to subscribe to events', async () => {
     const fnSubscription = jest.fn();
-    const objSubscription = {
-      add_hook: jest.fn(),
-      test_environment_setup: jest.fn(),
-      test_environment_teardown: jest.fn(),
-    };
-
     const originalMethods = {
       setup: jest.fn().mockResolvedValue(void 0),
       handleTestEvent: jest.fn().mockResolvedValue(void 0),
@@ -27,11 +21,7 @@ describe('EmitterMixin', () => {
       }
     }
 
-    const EnvironmentBase = JestEnvironmentEmit(
-      OriginalEnvironment as any,
-      objSubscription,
-      'Base',
-    );
+    const EnvironmentBase = JestEnvironmentEmit(OriginalEnvironment as any, undefined, 'Base');
     const Environment = EnvironmentBase.derive(fnSubscription, 'WithMocks');
 
     const config = {
@@ -42,25 +32,26 @@ describe('EmitterMixin', () => {
     const env = new Environment(config, context);
 
     expect(fnSubscription).not.toHaveBeenCalled();
-    expect(objSubscription.test_environment_setup).not.toHaveBeenCalled();
     await env.setup();
     expect(originalMethods.setup).toHaveBeenCalled();
-    expect(objSubscription.test_environment_setup).toHaveBeenCalled();
-    expect(fnSubscription).toHaveBeenCalledWith({
-      env,
-      testEvents: env.testEvents,
-      context,
-      config,
-    });
+    expect(fnSubscription).toHaveBeenCalledWith(
+      {
+        env,
+        context,
+        config,
+        testEvents: expect.objectContaining({
+          on: expect.any(Function),
+          once: expect.any(Function),
+          off: expect.any(Function),
+        }),
+      },
+      void 0,
+    );
 
-    expect(objSubscription.add_hook).not.toHaveBeenCalled();
     await env.handleTestEvent!({ name: 'add_hook' } as any, {} as any);
-    expect(objSubscription.add_hook).toHaveBeenCalled();
     expect(originalMethods.handleTestEvent).toHaveBeenCalled();
 
-    expect(objSubscription.test_environment_teardown).not.toHaveBeenCalled();
     await env.teardown();
-    expect(objSubscription.test_environment_teardown).toHaveBeenCalled();
     expect(originalMethods.teardown).toHaveBeenCalled();
   });
 });

--- a/src/callbacks/requireModule.ts
+++ b/src/callbacks/requireModule.ts
@@ -1,15 +1,15 @@
 import type { JestEnvironment } from '@jest/environment';
-import type { EmitterSubscription } from '../types';
+import type { EnvironmentListenerOnly } from '../types';
 import { logger } from '../utils';
 
 export async function requireModule<E extends JestEnvironment = JestEnvironment>(
   rootDir: string,
   moduleName: string,
-): Promise<EmitterSubscription<E> | null> {
+): Promise<EnvironmentListenerOnly<E> | null> {
   try {
     const cwdPath = require.resolve(moduleName, { paths: [rootDir] });
     const result = (await import(cwdPath)) as any;
-    return (result?.default ?? result) as EmitterSubscription<E>;
+    return (result?.default ?? result) as EnvironmentListenerOnly<E>;
   } catch (error: any) {
     logger.warn({ cat: 'import', err: error }, `Failed to resolve: ${moduleName}`);
     return null;

--- a/src/callbacks/resolveSubscription.test.ts
+++ b/src/callbacks/resolveSubscription.test.ts
@@ -5,4 +5,24 @@ describe('resolveSubscription', function () {
     const callback = await resolveSubscription(process.cwd(), undefined as any);
     expect(callback).not.toThrow();
   });
+
+  it('should pass through a function', async function () {
+    const fn = jest.fn();
+    const callback = await resolveSubscription(process.cwd(), fn);
+    expect(callback).toBe(fn);
+  });
+
+  it('should resolve a module name', async function () {
+    const identity = await resolveSubscription(process.cwd(), 'lodash/identity');
+    const someObject = {} as any;
+    expect(identity(someObject)).toBe(someObject);
+  });
+
+  it('should resolve a smart object', async function () {
+    const setup = jest.fn();
+    const listener = await resolveSubscription(process.cwd(), { setup });
+    const context = { testEvents: { on: jest.fn() } } as any;
+    listener(context);
+    expect(context.testEvents.on).toHaveBeenCalledWith('setup', setup);
+  });
 });

--- a/src/callbacks/resolveSubscription.test.ts
+++ b/src/callbacks/resolveSubscription.test.ts
@@ -2,27 +2,19 @@ import { resolveSubscription } from './resolveSubscription';
 
 describe('resolveSubscription', function () {
   it('should tolerate falsy values', async function () {
-    const callback = await resolveSubscription(process.cwd(), undefined as any);
+    const [callback] = await resolveSubscription(process.cwd(), undefined as any);
     expect(callback).not.toThrow();
   });
 
   it('should pass through a function', async function () {
     const fn = jest.fn();
-    const callback = await resolveSubscription(process.cwd(), fn);
+    const [callback] = await resolveSubscription(process.cwd(), fn);
     expect(callback).toBe(fn);
   });
 
   it('should resolve a module name', async function () {
-    const identity = await resolveSubscription(process.cwd(), 'lodash/identity');
+    const [identity] = await resolveSubscription(process.cwd(), 'lodash/identity');
     const someObject = {} as any;
     expect(identity(someObject)).toBe(someObject);
-  });
-
-  it('should resolve a smart object', async function () {
-    const setup = jest.fn();
-    const listener = await resolveSubscription(process.cwd(), { setup });
-    const context = { testEvents: { on: jest.fn() } } as any;
-    listener(context);
-    expect(context.testEvents.on).toHaveBeenCalledWith('setup', setup);
   });
 });

--- a/src/callbacks/resolveSubscription.ts
+++ b/src/callbacks/resolveSubscription.ts
@@ -1,26 +1,41 @@
 import type { JestEnvironment } from '@jest/environment';
-import type { EmitterSubscription, EmitterSubscriptionCallback } from '../types';
+import type {
+  EnvironmentListener,
+  EnvironmentListenerFn,
+  EnvironmentListenerOnly,
+  EnvironmentListenerWithOptions,
+} from '../types';
+
 import { requireModule } from './requireModule';
+
+export type ResolvedEnvironmentListener<E extends JestEnvironment = JestEnvironment> = [
+  EnvironmentListenerFn<E>,
+  any,
+];
 
 export async function resolveSubscription<E extends JestEnvironment = JestEnvironment>(
   rootDir: string,
-  registration: EmitterSubscription<E> | string | null,
-): Promise<EmitterSubscriptionCallback<E>> {
-  if (registration == null) {
-    return () => {};
+  registration: EnvironmentListener<E> | null,
+): Promise<ResolvedEnvironmentListener<E>> {
+  if (Array.isArray(registration)) {
+    const [callback, options] = registration as EnvironmentListenerWithOptions<E>;
+    return [await resolveSubscriptionSingle(rootDir, callback), options];
   }
 
-  if (typeof registration === 'string') {
-    return resolveSubscription(rootDir, await requireModule(rootDir, registration));
-  }
+  return [await resolveSubscriptionSingle(rootDir, registration), undefined];
+}
 
+export async function resolveSubscriptionSingle<E extends JestEnvironment = JestEnvironment>(
+  rootDir: string,
+  registration: EnvironmentListenerOnly<E> | null,
+): Promise<EnvironmentListenerFn<E>> {
   if (typeof registration === 'function') {
     return registration;
   }
 
-  return (context) => {
-    for (const [type, listener] of Object.entries(registration)) {
-      context.testEvents.on(type as any, listener as any);
-    }
-  };
+  if (typeof registration === 'string') {
+    return resolveSubscriptionSingle(rootDir, await requireModule(rootDir, registration));
+  }
+
+  return () => {};
 }

--- a/src/callbacks/resolveSubscription.ts
+++ b/src/callbacks/resolveSubscription.ts
@@ -4,7 +4,7 @@ import { requireModule } from './requireModule';
 
 export async function resolveSubscription<E extends JestEnvironment = JestEnvironment>(
   rootDir: string,
-  registration: EmitterSubscription<E> | null,
+  registration: EmitterSubscription<E> | string | null,
 ): Promise<EmitterSubscriptionCallback<E>> {
   if (registration == null) {
     return () => {};

--- a/src/jsdom.ts
+++ b/src/jsdom.ts
@@ -1,5 +1,5 @@
 import JestEnvironmentJsdom from 'jest-environment-jsdom';
-import { EmitterMixin } from './index';
+import { WithEmitter } from './index';
 
-export const TestEnvironment = EmitterMixin(JestEnvironmentJsdom);
+export const TestEnvironment = WithEmitter(JestEnvironmentJsdom);
 export default TestEnvironment;

--- a/src/node.ts
+++ b/src/node.ts
@@ -1,5 +1,5 @@
 import JestEnvironmentNode from 'jest-environment-node';
-import { EmitterMixin } from './index';
+import { WithEmitter } from './index';
 
-export const TestEnvironment = EmitterMixin(JestEnvironmentNode);
+export const TestEnvironment = WithEmitter(JestEnvironmentNode);
 export default TestEnvironment;

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,7 +24,7 @@ export type TestEnvironmentCircusEvent<E extends Circus.Event = Circus.Event> = 
   state: Circus.State;
 };
 
-export type WithEmitter<E extends JestEnvironment = JestEnvironment> = E & {
+export type HasEmitter<E extends JestEnvironment = JestEnvironment> = E & {
   readonly testEvents: ReadonlyAsyncEmitter<TestEnvironmentEvent>;
 };
 
@@ -48,7 +48,6 @@ export type EmitterSubscriptionCallback<E extends JestEnvironment = JestEnvironm
 ) => void;
 
 export type EmitterSubscription<E extends JestEnvironment = JestEnvironment> =
-  | string
   | EmitterSubscriptionCallback<E>
   | Partial<
       {

--- a/src/types.ts
+++ b/src/types.ts
@@ -24,50 +24,29 @@ export type TestEnvironmentCircusEvent<E extends Circus.Event = Circus.Event> = 
   state: Circus.State;
 };
 
-export type HasEmitter<E extends JestEnvironment = JestEnvironment> = E & {
-  readonly testEvents: ReadonlyAsyncEmitter<TestEnvironmentEvent>;
-};
+export type EnvironmentListener<E extends JestEnvironment = JestEnvironment> =
+  | EnvironmentListenerWithOptions<E>
+  | EnvironmentListenerOnly<E>;
 
-export type EmitterSubscriptionContext<E extends JestEnvironment = JestEnvironment> = {
+export type EnvironmentListenerWithOptions<E extends JestEnvironment = JestEnvironment> = [
+  EnvironmentListenerOnly<E>,
+  any,
+];
+
+export type EnvironmentListenerOnly<E extends JestEnvironment = JestEnvironment> =
+  | EnvironmentListenerFn<E>
+  | string;
+
+export type EnvironmentListenerFn<E extends JestEnvironment = JestEnvironment> = (
+  context: Readonly<EnvironmentListenerContext<E>>,
+  listenerConfig?: any,
+) => void;
+
+export type EnvironmentListenerContext<E extends JestEnvironment = JestEnvironment> = {
   env: E;
   testEvents: ReadonlyAsyncEmitter<TestEnvironmentEvent>;
   context: EnvironmentContext;
   config: JestEnvironmentConfig;
 };
-
-export type AsyncTestEventListener<E extends TestEnvironmentEvent = TestEnvironmentEvent> = (
-  event: E,
-) => void | Promise<void>;
-
-export type SyncTestEventListener<E extends TestEnvironmentEvent = TestEnvironmentEvent> = (
-  event: E,
-) => void;
-
-export type EmitterSubscriptionCallback<E extends JestEnvironment = JestEnvironment> = (
-  context: Readonly<EmitterSubscriptionContext<E>>,
-) => void;
-
-export type EmitterSubscription<E extends JestEnvironment = JestEnvironment> =
-  | EmitterSubscriptionCallback<E>
-  | Partial<
-      {
-        '*': AsyncTestEventListener;
-        test_environment_setup: AsyncTestEventListener<TestEnvironmentSetupEvent>;
-        test_environment_teardown: AsyncTestEventListener<TestEnvironmentTeardownEvent>;
-        start_describe_definition: SyncTestEventListener<
-          TestEnvironmentCircusEvent & { type: 'start_describe_definition' }
-        >;
-        finish_describe_definition: SyncTestEventListener<
-          TestEnvironmentCircusEvent & { type: 'finish_describe_definition' }
-        >;
-        add_hook: SyncTestEventListener<TestEnvironmentCircusEvent & { type: 'add_hook' }>;
-        add_test: SyncTestEventListener<TestEnvironmentCircusEvent & { type: 'add_test' }>;
-        error: SyncTestEventListener<TestEnvironmentCircusEvent & { type: 'error' }>;
-      } & {
-        [key in TestEnvironmentEvent['type']]: AsyncTestEventListener<
-          TestEnvironmentCircusEvent & { type: key }
-        >;
-      }
-    >;
 
 export type { ReadonlyAsyncEmitter } from './emitters';

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -8,6 +8,15 @@ bunyamin.threadGroups.push({
   displayName: PACKAGE_NAME,
 });
 
+bunyamin.logger = {
+  fatal: console.error,
+  error: console.error,
+  warn: console.warn,
+  info: console.log,
+  debug: console.log,
+  trace: console.log,
+};
+
 export const logger = isDebug(PACKAGE_NAME) ? bunyamin : nobunyamin;
 
 // eslint-disable-next-line @typescript-eslint/no-explicit-any

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,7 +1,7 @@
 {
   "compilerOptions": {
     "target": "es2022",
-    "module": "commonjs",
+    "module": "node16",
     "declaration": true,
     "sourceMap": true,
     "outDir": "./dist",
@@ -10,6 +10,7 @@
     "importsNotUsedAsValues": "error",
     "ignoreDeprecations": "5.0",
     "strict": true,
+    "esModuleInterop": true,
     "noImplicitAny": true,
     "strictNullChecks": true,
     "strictFunctionTypes": true,


### PR DESCRIPTION
The project underwent some simplifications:

* no smart objects – they don't work well with multiple Jest workers
* callbacks in static derivation
* module paths in via-config extending