### PR TITLE
fix: esm collision between default and named exports

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,5 @@
 coverage/**
 dist/**
+package-e2e/**
 *.js
+*.mjs

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -28,6 +28,18 @@ jobs:
         run: npm run lint:ci
       - name: Unit Tests
         run: npm test
+      - name: Pack
+        run: npm pack
+      - name: E2E Tests
+        run: npm run test:e2e
+      - name: Install package-e2e project
+        uses: bahmutov/npm-install@v1
+        with:
+          useLockFile: false
+          working-directory: 'package-e2e'
+      - name: Packaging E2E Tests
+        run: npm test
+        working-directory: 'package-e2e'
 
   publish:
     name: Publish

--- a/debug.js
+++ b/debug.js
@@ -1,2 +1,1 @@
-/* Jest 27 fallback */
 module.exports = require('./dist/debug');

--- a/debug.mjs
+++ b/debug.mjs
@@ -1,0 +1,1 @@
+export * from './dist/debug.js';

--- a/e2e/jest.config.js
+++ b/e2e/jest.config.js
@@ -4,7 +4,7 @@ module.exports = {
   ...base,
 
   rootDir: '..',
-  testEnvironment: 'jest-environment-emit/node',
+  testEnvironment: './e2e/testEnvironment.js',
   testEnvironmentOptions: {
     eventListeners: [
       ['./e2e/listeners.cjs', { prefix: 'cjs' }],

--- a/e2e/listeners.cjs
+++ b/e2e/listeners.cjs
@@ -1,5 +1,6 @@
 /** @type {import('jest-environment-emit').EnvironmentListenerFn} */
-module.exports = ({ testEvents }, { prefix }) => {
+module.exports = ({ env, testEvents }, { prefix }) => {
+  env.counter--;
   testEvents.on('test_environment_teardown', () => {
     console.log(`[${prefix}] test_environment_teardown`);
   });

--- a/e2e/listeners.mjs
+++ b/e2e/listeners.mjs
@@ -1,5 +1,6 @@
 /** @type {import('jest-environment-emit').EnvironmentListenerFn} */
-export default ({ testEvents }, { prefix }) => {
+export default ({ env, testEvents }, { prefix }) => {
+  env.counter--;
   testEvents.on('test_environment_teardown', () => {
     console.log(`[${prefix}] test_environment_teardown`);
   });

--- a/e2e/testEnvironment.js
+++ b/e2e/testEnvironment.js
@@ -1,0 +1,17 @@
+const TestEnvironment = require('jest-environment-emit/node').default;
+
+class E2ETestEnvironment extends TestEnvironment {
+  constructor(config, context) {
+    super(config, context);
+    this.counter = 2;
+  }
+
+  async teardown() {
+    await super.teardown();
+    if (this.counter !== 0) {
+      throw new Error('There was an issue with listeners registration or execution');
+    }
+  }
+}
+
+module.exports = E2ETestEnvironment;

--- a/index.js
+++ b/index.js
@@ -1,2 +1,1 @@
-/* Jest 27 fallback */
 module.exports = require('./dist/index');

--- a/index.mjs
+++ b/index.mjs
@@ -1,0 +1,6 @@
+import index from './dist/index.js';
+
+const { WithEmitter } = index;
+
+export { WithEmitter };
+export default WithEmitter;

--- a/jsdom.mjs
+++ b/jsdom.mjs
@@ -1,0 +1,7 @@
+import jsdom from './dist/jsdom.js';
+
+const { TestEnvironment } = jsdom;
+
+export { TestEnvironment };
+export default TestEnvironment;
+

--- a/node.js
+++ b/node.js
@@ -1,2 +1,1 @@
-/* Jest 27 fallback */
 module.exports = require('./dist/node');

--- a/node.mjs
+++ b/node.mjs
@@ -1,0 +1,6 @@
+import node from './dist/node.js';
+
+const { TestEnvironment } = node;
+
+export { TestEnvironment };
+export default TestEnvironment;

--- a/package-e2e/.npmrc
+++ b/package-e2e/.npmrc
@@ -1,0 +1,1 @@
+package-lock=false

--- a/package-e2e/package.json
+++ b/package-e2e/package.json
@@ -1,0 +1,18 @@
+{
+  "name": "@jest-environment-emit/package-e2e",
+  "private": true,
+  "version": "1.0.0",
+  "description": "",
+  "scripts": {
+    "test": "node test.cjs && node test.mjs && tsc",
+    "test:cjs": "node test.cjs",
+    "test:mjs": "node test.mjs",
+    "test:ts": "tsc"
+  },
+  "dependencies": {
+    "jest-environment-emit": "file:../jest-environment-emit-1.0.0.tgz"
+  },
+  "devDependencies": {
+    "typescript": "^5.3.3"
+  }
+}

--- a/package-e2e/test.cjs
+++ b/package-e2e/test.cjs
@@ -1,0 +1,16 @@
+const assert = require('assert');
+
+const index = require('jest-environment-emit');
+assert(typeof index.default === 'function', 'jest-environment-emit should have a function as its default export');
+assert.strictEqual(index.default, index.WithEmitter, 'jest-environment-emit should have a named alternative to its default export');
+
+const jsdom = require('jest-environment-emit/jsdom');
+assert(typeof jsdom.default === 'function', 'jest-environment-emit/jsdom should have a function as its default export');
+assert.strictEqual(jsdom.default, jsdom.TestEnvironment, 'jest-environment-emit/jsdom should have a named export `TestEnvironment`');
+
+const node = require('jest-environment-emit/node');
+assert(typeof node.default === 'function', 'jest-environment-emit/node should have a function as its default export');
+assert.strictEqual(node.default, node.TestEnvironment, 'jest-environment-emit/node should have a named export `TestEnvironment`');
+
+const debug = require('jest-environment-emit/debug');
+assert(typeof debug.aggregateLogs === 'function', 'jest-environment-emit/debug should have a named export `aggregateLogs`');

--- a/package-e2e/test.js
+++ b/package-e2e/test.js
@@ -1,0 +1,16 @@
+"use strict";
+Object.defineProperty(exports, "__esModule", { value: true });
+var jest_environment_emit_1 = require("jest-environment-emit");
+var jsdom_1 = require("jest-environment-emit/jsdom");
+var node_1 = require("jest-environment-emit/node");
+var debug_1 = require("jest-environment-emit/debug");
+function assertType(_actual) {
+    // no-op
+}
+assertType(jest_environment_emit_1.default);
+assertType(jest_environment_emit_1.WithEmitter);
+assertType(jsdom_1.default);
+assertType(jsdom_1.TestEnvironment);
+assertType(node_1.default);
+assertType(node_1.TestEnvironment);
+assertType(debug_1.aggregateLogs);

--- a/package-e2e/test.mjs
+++ b/package-e2e/test.mjs
@@ -1,0 +1,17 @@
+import assert from 'assert';
+
+const index = await import('jest-environment-emit');
+assert(typeof index.default === 'function', 'jest-environment-emit should have a function as its default export');
+assert.strictEqual(index.default, index.WithEmitter, 'jest-environment-emit should have a named alternative to its default export');
+
+const jsdom = await import('jest-environment-emit/jsdom');
+assert(typeof jsdom.default === 'function', 'jest-environment-emit/jsdom should have a function as its default export');
+assert.strictEqual(jsdom.default, jsdom.TestEnvironment, 'jest-environment-emit/jsdom should have a named export `TestEnvironment`');
+
+const node = await import('jest-environment-emit/node');
+assert(typeof node.default === 'function', 'jest-environment-emit/node should have a function as its default export');
+assert.strictEqual(node.default, node.TestEnvironment, 'jest-environment-emit/node should have a named export `TestEnvironment`');
+
+const debug = await import('jest-environment-emit/debug');
+assert(typeof debug.aggregateLogs === 'function', 'jest-environment-emit/debug should have a named export `aggregateLogs`');
+

--- a/package-e2e/test.ts
+++ b/package-e2e/test.ts
@@ -1,0 +1,16 @@
+import WithEmitter, { WithEmitter as WithEmitterNamed } from 'jest-environment-emit';
+import JsdomTestEnvironment, { TestEnvironment as JsdomTestEnvironmentNamed } from 'jest-environment-emit/jsdom';
+import NodeTestEnvironment, { TestEnvironment as NodeTestEnvironmentNamed } from 'jest-environment-emit/node';
+import { aggregateLogs } from 'jest-environment-emit/debug';
+
+function assertType<T>(_actual: T): void {
+  // no-op
+}
+
+assertType<Function>(WithEmitter);
+assertType<Function>(WithEmitterNamed);
+assertType<Function>(JsdomTestEnvironment);
+assertType<Function>(JsdomTestEnvironmentNamed);
+assertType<Function>(NodeTestEnvironment);
+assertType<Function>(NodeTestEnvironmentNamed);
+assertType<Function>(aggregateLogs);

--- a/package-e2e/tsconfig.json
+++ b/package-e2e/tsconfig.json
@@ -1,0 +1,14 @@
+{
+  "compilerOptions": {
+    "target": "ES2022",
+    "module": "Node16",
+    "moduleResolution": "Node16",
+    "esModuleInterop": true,
+    "allowSyntheticDefaultImports": true,
+    "strict": true,
+    "noEmit": true
+  },
+  "files": [
+    "test.ts"
+  ],
+}

--- a/package.json
+++ b/package.json
@@ -9,29 +9,30 @@
     "src",
     "dist",
     "*.js",
+    "*.mjs",
     "!**/__utils__",
     "!**/__tests__",
     "!**/*.test.*"
   ],
   "exports": {
     ".": {
-      "import": "./dist/index.js",
-      "require": "./dist/index.js",
+      "import": "./index.mjs",
+      "require": "./index.js",
       "types": "./dist/index.d.ts"
     },
     "./jsdom": {
-      "import": "./dist/jsdom.js",
-      "require": "./dist/jsdom.js",
+      "import": "./jsdom.mjs",
+      "require": "./jsdom.js",
       "types": "./dist/jsdom.d.ts"
     },
     "./node": {
-      "import": "./dist/node.js",
-      "require": "./dist/node.js",
+      "import": "./node.mjs",
+      "require": "./node.js",
       "types": "./dist/node.d.ts"
     },
     "./debug": {
-      "import": "./dist/debug.js",
-      "require": "./dist/debug.js",
+      "import": "./debug.mjs",
+      "require": "./debug.js",
       "types": "./dist/debug.d.ts"
     },
     "./package.json": "./package.json"
@@ -46,7 +47,8 @@
     "lint": "eslint . --fix",
     "lint:ci": "eslint .",
     "lint:staged": "lint-staged",
-    "test": "jest"
+    "test": "jest",
+    "test:e2e": "jest --config e2e/jest.config.js"
   },
   "repository": {
     "type": "git",

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -1,5 +1,5 @@
-import fs from 'fs';
-import path from 'path';
+import * as fs from 'node:fs';
+import * as path from 'node:path';
 import {
   bunyamin,
   isDebug,

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,6 +4,7 @@
     "module": "node16",
     "declaration": true,
     "sourceMap": true,
+    "removeComments": true,
     "outDir": "./dist",
     "rootDir": "./src",
     "importHelpers": true,


### PR DESCRIPTION
Resolves #5.

Adds E2E and packaging self-tests to the CI pipeline.