### PR TITLE
fix: module.exports.default fallback for quirky imports

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,1 +1,2 @@
 module.exports = require('./dist/index').default;
+module.exports.default = module.exports;

--- a/jsdom.js
+++ b/jsdom.js
@@ -1,1 +1,2 @@
 module.exports = require('./dist/jsdom').default;
+module.exports.default = module.exports;

--- a/node.js
+++ b/node.js
@@ -1,1 +1,2 @@
 module.exports = require('./dist/node').default;
+module.exports.default = module.exports;

--- a/package-e2e/test.cjs
+++ b/package-e2e/test.cjs
@@ -2,12 +2,15 @@ const assert = require('assert');
 
 const WithEmitter = require('jest-environment-emit');
 assert(typeof WithEmitter === 'function', 'jest-environment-emit should have a function as its default export');
+assert(WithEmitter.default === WithEmitter, 'jest-environment-emit should have a default export fallback to itself');
 
 const JestEnvironmentEmitJsDOM = require('jest-environment-emit/jsdom');
 assert(typeof JestEnvironmentEmitJsDOM === 'function', 'jest-environment-emit/jsdom should have a function as its default export');
+assert(JestEnvironmentEmitJsDOM.default === JestEnvironmentEmitJsDOM, 'jest-environment-emit/jsdom should have a default export fallback to itself');
 
 const JestEnvironmentEmitNode = require('jest-environment-emit/node');
 assert(typeof JestEnvironmentEmitNode === 'function', 'jest-environment-emit/node should have a function as its default export');
+assert(JestEnvironmentEmitNode.default === JestEnvironmentEmitNode, 'jest-environment-emit/node should have a default export fallback to itself');
 
 const debug = require('jest-environment-emit/debug');
 assert(typeof debug.aggregateLogs === 'function', 'jest-environment-emit/debug should have a named export `aggregateLogs`');


### PR DESCRIPTION
Allows naive imports like `require('jest-environment-emit').default` to work equally well as require('jest-environment-emit')`.