### PR TITLE
fix: trace logging

### DIFF
--- a/e2e/globalTeardown.js
+++ b/e2e/globalTeardown.js
@@ -1,0 +1,1 @@
+module.exports = require('jest-environment-emit/debug').aggregateLogs;

--- a/e2e/jest.config.js
+++ b/e2e/jest.config.js
@@ -4,6 +4,7 @@ module.exports = {
   ...base,
 
   rootDir: '..',
+  globalTeardown: './e2e/globalTeardown',
   testEnvironment: './e2e/testEnvironment.js',
   testEnvironmentOptions: {
     eventListeners: [

--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
   },
   "homepage": "https://github.com/wix-incubator/jest-environment-emit#readme",
   "dependencies": {
-    "bunyamin": "^1.5.0",
+    "bunyamin": "^1.5.2",
     "bunyan": "^2.0.5",
     "bunyan-debug-stream": "^3.1.0",
     "funpermaproxy": "^1.1.0",

--- a/src/emitters/ReadonlyEmitterBase.ts
+++ b/src/emitters/ReadonlyEmitterBase.ts
@@ -1,5 +1,5 @@
 /* eslint-disable @typescript-eslint/ban-types */
-import { logger, optimizeTracing, iterateSorted } from '../utils';
+import { debugLogger, optimizeTracing, iterateSorted } from '../utils';
 import type { ReadonlyEmitter } from './Emitter';
 
 //#region Optimized event helpers
@@ -15,13 +15,13 @@ const __LISTENERS = optimizeTracing((listener: unknown) => ({
 const ONCE: unique symbol = Symbol('ONCE');
 
 export abstract class ReadonlyEmitterBase<EventMap> implements ReadonlyEmitter<EventMap> {
-  protected readonly _log: typeof logger;
+  protected readonly _log: typeof debugLogger;
   protected readonly _listeners: Map<keyof EventMap | '*', [Function, number][]> = new Map();
 
   #listenersCounter = 0;
 
   constructor(name: string) {
-    this._log = logger.child({
+    this._log = debugLogger.child({
       cat: `emitter`,
       tid: [name, {}],
     });

--- a/src/emitters/syncEmitterCommons.ts
+++ b/src/emitters/syncEmitterCommons.ts
@@ -6,11 +6,14 @@ const CATEGORIES = {
   INVOKE: ['invoke'],
 };
 
-export const __ENQUEUE = optimizeTracing((event: unknown) => ({
+export const __ENQUEUE = optimizeTracing((_event: unknown) => ({
   cat: CATEGORIES.ENQUEUE,
-  event,
 }));
-export const __EMIT = optimizeTracing((event: unknown) => ({ cat: CATEGORIES.EMIT, event }));
+
+export const __EMIT = optimizeTracing((_event: unknown) => ({
+  cat: CATEGORIES.EMIT,
+}));
+
 export const __INVOKE = optimizeTracing((listener: unknown, type?: '*') => ({
   cat: CATEGORIES.INVOKE,
   fn: `${listener}`,

--- a/src/hooks.ts
+++ b/src/hooks.ts
@@ -10,7 +10,7 @@ import type {
   TestEnvironmentSyncEventMap,
   EnvironmentEventEmitter,
 } from './types';
-import { getHierarchy } from './utils';
+import { debugLogger, getHierarchy } from './utils';
 
 type EnvironmentEventEmitterImpl = SemiAsyncEmitter<
   TestEnvironmentAsyncEventMap,
@@ -42,9 +42,18 @@ export function onTestEnvironmentCreate(
     'error',
   ]);
 
+  const environmentConfig = normalizeJestEnvironmentConfig(jestEnvironmentConfig);
+  debugLogger.trace(
+    {
+      testPath: environmentContext.testPath,
+      environmentConfig,
+    },
+    'test_environment_create',
+  );
+
   contexts.set(jestEnvironment, {
     testEvents,
-    environmentConfig: normalizeJestEnvironmentConfig(jestEnvironmentConfig),
+    environmentConfig,
     environmentContext,
   });
 }

--- a/src/utils/logger.ts
+++ b/src/utils/logger.ts
@@ -2,6 +2,7 @@ import * as fs from 'node:fs';
 import * as path from 'node:path';
 import {
   bunyamin,
+  nobunyamin,
   isDebug,
   threadGroups,
   traceEventStream,
@@ -13,7 +14,7 @@ import { noop } from './noop';
 
 const logsDirectory = process.env.JEST_BUNYAMIN_DIR;
 const LOG_PATTERN = /^jest-bunyamin\..*\.log$/;
-const PACKAGE_NAME = 'jest-enviroment-emit' as const;
+const PACKAGE_NAME = 'jest-environment-emit' as const;
 
 function isTraceEnabled(): boolean {
   return !!logsDirectory;
@@ -111,6 +112,8 @@ export const logger = bunyamin.child({
   cat: PACKAGE_NAME,
 });
 
-export const optimizeTracing: <F>(f: F) => F = isDebug(PACKAGE_NAME)
-  ? (f) => f
-  : ((() => noop) as any);
+const isDebugMode = isDebug(PACKAGE_NAME);
+
+export const debugLogger = isDebugMode ? logger : nobunyamin;
+
+export const optimizeTracing: <F>(f: F) => F = isDebugMode ? (f) => f : ((() => noop) as any);


### PR DESCRIPTION
Scope:

1. Fix an incorrect `$DEBUG` regexp (typo).
2. Fix serialization errors in `DEBUG=jest-environment-emit` mode.
3. Ensure the logger does not emit trace messages in non-DEBUG mode — prevent log pollution.